### PR TITLE
Add privacy and terms policies

### DIFF
--- a/chinese-foods.html
+++ b/chinese-foods.html
@@ -331,11 +331,17 @@
                         <li><a href="foods.html" data-i18n="nav.foods">Food Library</a></li>
                         <li><a href="chinese-foods.html" data-i18n="nav.chinese">Chinese Cuisine</a></li>
                         <li><a href="game.html" data-i18n="nav.game">Nutrition Game</a></li>
+                        <li><a href="privacy-policy.html" data-i18n="footer.privacyPolicy">Privacy Policy</a></li>
+                        <li><a href="terms-of-service.html" data-i18n="footer.termsOfService">Terms of Service</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
                 <p>&copy; 2024 <span data-i18n="footer.copyright">Nutrition Breakfast. All rights reserved.</span></p>
+                <div class="footer-legal-links">
+                    <a href="privacy-policy.html" data-i18n="footer.privacyPolicy">Privacy Policy</a>
+                    <a href="terms-of-service.html" data-i18n="footer.termsOfService">Terms of Service</a>
+                </div>
                 <p><a href="https://www.seodog.cn" target="_blank" rel="noopener noreferrer" class="ai-tools-link-simple" data-i18n="footer.aiTools">🔗 AI Tools Navigation - SEOdog.cn</a></p>
             </div>
         </div>

--- a/city-foods.html
+++ b/city-foods.html
@@ -329,7 +329,13 @@
     <!-- 页脚 -->
     <footer class="footer">
         <div class="container">
-            <p>&copy; 2024 营养早餐. All rights reserved.</p>
+            <div class="footer-bottom">
+                <p data-i18n="footer.copyright">&copy; 2024 营养早餐. 保留所有权利.</p>
+                <div class="footer-legal-links">
+                    <a href="privacy-policy.html" data-i18n="footer.privacyPolicy">隐私政策</a>
+                    <a href="terms-of-service.html" data-i18n="footer.termsOfService">服务条款</a>
+                </div>
+            </div>
         </div>
     </footer>
 

--- a/food-roulette.html
+++ b/food-roulette.html
@@ -379,11 +379,17 @@
                         <li><a href="foods.html" data-i18n="nav.foods">Food Library</a></li>
                         <li><a href="chinese-foods.html" data-i18n="nav.chinese">Chinese Cuisine</a></li>
                         <li><a href="game.html" data-i18n="nav.game">Nutrition Game</a></li>
+                        <li><a href="privacy-policy.html" data-i18n="footer.privacyPolicy">Privacy Policy</a></li>
+                        <li><a href="terms-of-service.html" data-i18n="footer.termsOfService">Terms of Service</a></li>
                     </ul>
                 </div>
             </div>
             <div class="footer-bottom">
                 <p>&copy; 2024 <span data-i18n="footer.copyright">Nutrition Breakfast. All rights reserved.</span></p>
+                <div class="footer-legal-links">
+                    <a href="privacy-policy.html" data-i18n="footer.privacyPolicy">Privacy Policy</a>
+                    <a href="terms-of-service.html" data-i18n="footer.termsOfService">Terms of Service</a>
+                </div>
                 <p><a href="https://www.seodog.cn" target="_blank" rel="noopener noreferrer" class="ai-tools-link-simple" data-i18n="footer.aiTools">🔗 AI Tools Navigation - SEOdog.cn</a></p>
             </div>
         </div>

--- a/foods.html
+++ b/foods.html
@@ -159,6 +159,8 @@
                         <li><a href="index.html" data-i18n="nav.home">首页</a></li>
                         <li><a href="foods.html" data-i18n="nav.foods">食物库</a></li>
                         <li><a href="game.html" data-i18n="nav.game">营养游戏</a></li>
+                        <li><a href="privacy-policy.html" data-i18n="footer.privacyPolicy">隐私政策</a></li>
+                        <li><a href="terms-of-service.html" data-i18n="footer.termsOfService">服务条款</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">
@@ -170,6 +172,10 @@
             </div>
             <div class="footer-bottom">
                 <p data-i18n="footer.copyright">&copy; 2024 营养早餐. 保留所有权利.</p>
+                <div class="footer-legal-links">
+                    <a href="privacy-policy.html" data-i18n="footer.privacyPolicy">隐私政策</a>
+                    <a href="terms-of-service.html" data-i18n="footer.termsOfService">服务条款</a>
+                </div>
                 <p><a href="https://www.seodog.cn" target="_blank" rel="noopener noreferrer" class="ai-tools-link"><span class="link-icon">🔗</span> <span data-i18n="footer.aiTools">AI工具导航</span> - SEOdog.cn</a></p>
             </div>
         </div>

--- a/game.html
+++ b/game.html
@@ -228,6 +228,8 @@
                         <li><a href="index.html" data-i18n="nav.home">首页</a></li>
                         <li><a href="foods.html" data-i18n="nav.foods">食物库</a></li>
                         <li><a href="game.html" data-i18n="nav.game">营养游戏</a></li>
+                        <li><a href="privacy-policy.html" data-i18n="footer.privacyPolicy">隐私政策</a></li>
+                        <li><a href="terms-of-service.html" data-i18n="footer.termsOfService">服务条款</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">
@@ -239,6 +241,10 @@
             </div>
             <div class="footer-bottom">
                 <p data-i18n="footer.copyright">&copy; 2024 营养早餐. 保留所有权利.</p>
+                <div class="footer-legal-links">
+                    <a href="privacy-policy.html" data-i18n="footer.privacyPolicy">隐私政策</a>
+                    <a href="terms-of-service.html" data-i18n="footer.termsOfService">服务条款</a>
+                </div>
                 <p><a href="https://www.seodog.cn" target="_blank" rel="noopener noreferrer" class="ai-tools-link"><span class="link-icon">🔗</span> <span data-i18n="footer.aiTools">AI工具导航</span> - SEOdog.cn</a></p>
             </div>
         </div>

--- a/i18n.js
+++ b/i18n.js
@@ -231,6 +231,8 @@ const i18nData = {
             phone: "电话",
             phoneNumber: "0",
             aiTools: "AI工具导航",
+            privacyPolicy: "隐私政策",
+            termsOfService: "服务条款",
             copyright: "© 2024 营养早餐. 保留所有权利."
         },
         
@@ -451,6 +453,8 @@ const i18nData = {
             phone: "Phone",
             phoneNumber: "0",
             aiTools: "AI Tools Navigation",
+            privacyPolicy: "Privacy Policy",
+            termsOfService: "Terms of Service",
             copyright: "© 2024 Nutrition Breakfast. All rights reserved."
         },
         

--- a/index.html
+++ b/index.html
@@ -224,6 +224,8 @@
                         <li><a href="index.html" data-i18n="nav.home">首页</a></li>
                         <li><a href="foods.html" data-i18n="nav.foods">食物库</a></li>
                         <li><a href="game.html" data-i18n="nav.game">营养游戏</a></li>
+                        <li><a href="privacy-policy.html" data-i18n="footer.privacyPolicy">隐私政策</a></li>
+                        <li><a href="terms-of-service.html" data-i18n="footer.termsOfService">服务条款</a></li>
                     </ul>
                 </div>
                 <div class="footer-section">
@@ -235,6 +237,10 @@
             </div>
             <div class="footer-bottom">
                 <p data-i18n="footer.copyright">&copy; 2024 营养早餐. 保留所有权利.</p>
+                <div class="footer-legal-links">
+                    <a href="privacy-policy.html" data-i18n="footer.privacyPolicy">隐私政策</a>
+                    <a href="terms-of-service.html" data-i18n="footer.termsOfService">服务条款</a>
+                </div>
                 <p><a href="https://www.seodog.cn" target="_blank" rel="noopener noreferrer" class="ai-tools-link"><span class="link-icon">🔗</span> <span data-i18n="footer.aiTools">AI工具导航</span> - SEOdog.cn</a></p>
             </div>
         </div>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Privacy Policy | Nutrition Breakfast</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="policy-page">
+    <nav class="navbar">
+        <div class="nav-container">
+            <div class="nav-logo">
+                <h2>🍳 <span data-i18n="nav.title">营养早餐</span></h2>
+            </div>
+            <ul class="nav-menu">
+                <li class="nav-item"><a href="index.html" class="nav-link" data-i18n="nav.home">Home</a></li>
+                <li class="nav-item"><a href="foods.html" class="nav-link" data-i18n="nav.foods">Food Database</a></li>
+                <li class="nav-item"><a href="chinese-foods.html" class="nav-link" data-i18n="nav.chinese">Chinese Cuisine</a></li>
+                <li class="nav-item"><a href="city-foods.html" class="nav-link" data-i18n="nav.cityFoods">City Specialties</a></li>
+                <li class="nav-item"><a href="food-roulette.html" class="nav-link" data-i18n="nav.foodRoulette">Food Roulette</a></li>
+                <li class="nav-item"><a href="lunch-roulette.html" class="nav-link" data-i18n="nav.lunchRoulette">Lunch Roulette</a></li>
+                <li class="nav-item"><a href="game.html" class="nav-link" data-i18n="nav.game">Nutrition Game</a></li>
+            </ul>
+            <div class="language-switcher">
+                <button class="lang-btn" data-lang="zh" onclick="switchLanguage('zh')">中文</button>
+                <button class="lang-btn active" data-lang="en" onclick="switchLanguage('en')">English</button>
+            </div>
+        </div>
+    </nav>
+
+    <main class="policy-container">
+        <section class="policy-section">
+            <h1>Privacy Policy 隐私政策</h1>
+            <p class="policy-meta">Effective Date: 15 April 2024<br><span lang="zh">生效日期：2024 年 4 月 15 日</span></p>
+            <p>We are committed to protecting your personal information and being transparent about how data is collected and used on Nutrition Breakfast (foodpairing.online). This policy explains what information we gather, how it is used, and the choices available to you.<br><span lang="zh">我们致力于保护您的个人信息，并清晰说明在 Nutrition Breakfast（foodpairing.online）上如何收集和使用数据。本政策阐述我们收集的内容、用途以及您可选择的控制方式。</span></p>
+            <div class="policy-highlight">
+                <strong>Summary 摘要：</strong>
+                <p>We use cookies and analytics to improve the experience, run Google AdSense advertisements, and provide nutrition content for reference only. You can manage cookies in your browser, opt out of personalized ads, and disable Google Analytics tracking as described below.<br><span lang="zh">我们使用 Cookie 和分析工具来提升体验、投放 Google AdSense 广告，并仅以参考形式提供营养内容。您可按下文说明在浏览器中管理 Cookie，关闭个性化广告，并停用 Google Analytics 跟踪。</span></p>
+            </div>
+        </section>
+
+        <section class="policy-section">
+            <h2>1. Information We Collect 收集的信息</h2>
+            <ul class="policy-list">
+                <li><strong>Usage data:</strong> Standard technical details such as IP address, browser type, language preference, and visited pages are collected by our hosting analytics and Google Analytics to understand site performance.<br><span lang="zh"><strong>使用数据：</strong>我们通过主机分析和 Google Analytics 收集常见技术信息，例如 IP 地址、浏览器类型、语言偏好和访问页面，用于了解网站表现。</span></li>
+                <li><strong>Cookies and local storage:</strong> We store language preferences, bookmarked items, and similar settings in cookies or browser storage so the site remembers your choices.<br><span lang="zh"><strong>Cookie 与本地存储：</strong>我们会在 Cookie 或浏览器存储中保存语言偏好、收藏内容等设置，以便网站记住您的选择。</span></li>
+                <li><strong>Advertising data:</strong> Google AdSense and its partners may place cookies or use device identifiers to deliver relevant ads and report impressions.<br><span lang="zh"><strong>广告数据：</strong>Google AdSense 及其合作伙伴可能放置 Cookie 或使用设备标识，以投放相关广告并统计展示情况。</span></li>
+            </ul>
+        </section>
+
+        <section class="policy-section">
+            <h2>2. How We Use Data 数据使用方式</h2>
+            <ul class="policy-list">
+                <li>Provide, maintain, and improve site features such as the food database, games, and multilingual interface.<br><span lang="zh">用于提供、维护和改进食物数据库、互动游戏以及多语言界面等网站功能。</span></li>
+                <li>Understand aggregated traffic patterns through Google Analytics to guide future updates.<br><span lang="zh">通过 Google Analytics 了解整体访问情况，为后续更新提供参考。</span></li>
+                <li>Serve advertising through Google AdSense in accordance with Google’s <a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener noreferrer">Advertising Policies</a>.<br><span lang="zh">依照 Google <a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener noreferrer">广告政策</a> 展示 Google AdSense 广告。</span></li>
+            </ul>
+        </section>
+
+        <section class="policy-section">
+            <h2>3. Cookies and Tracking Cookie 及跟踪技术</h2>
+            <p>Cookies help remember your preferred language, keep roulette settings consistent, and support functionality such as bookmark storage. Third-party cookies from Google AdSense measure ad performance and may personalize content based on your interests.<br><span lang="zh">Cookie 有助于记住您的语言偏好、保持转盘设置一致，并支持收藏等功能。来自 Google AdSense 的第三方 Cookie 用于衡量广告效果，并可能根据您的兴趣个性化展示。</span></p>
+            <p>You can clear, block, or control cookies through your browser settings. Popular guidance is available from <a href="https://www.allaboutcookies.org/" target="_blank" rel="noopener noreferrer">All About Cookies</a>.<br><span lang="zh">您可通过浏览器设置清除、阻止或管理 Cookie。可参考 <a href="https://www.allaboutcookies.org/" target="_blank" rel="noopener noreferrer">All About Cookies</a> 等指南。</span></p>
+        </section>
+
+        <section class="policy-section">
+            <h2>4. Third-Party Advertising & Analytics 第三方广告与分析</h2>
+            <p>We partner with Google AdSense to display ads. AdSense may use cookies and advertising identifiers to show personalized ads and report aggregated metrics. Google may share information with certified partners when required for ad delivery or measurement.<br><span lang="zh">我们与 Google AdSense 合作展示广告。AdSense 会使用 Cookie 和广告标识符来投放个性化广告并统计汇总指标。Google 可能在必要时与认证合作伙伴共享信息，以完成广告投放或衡量。</span></p>
+            <p>We also implement Google Analytics (gtag.js) to understand how visitors use the site. Analytics collects anonymized statistics and never shares raw personal data with us.<br><span lang="zh">我们同时使用 Google Analytics（gtag.js）了解访问者如何使用本站。Analytics 收集的均为匿名统计信息，不会向我们提供可直接识别个人的原始数据。</span></p>
+        </section>
+
+        <section class="policy-section">
+            <h2>5. Your Choices and Opt-Out Options 您的选择与退出方式</h2>
+            <ul class="policy-list">
+                <li><strong>Ad personalization:</strong> Visit <a href="https://adssettings.google.com/" target="_blank" rel="noopener noreferrer">Google Ads Settings</a> to manage personalized ads, or opt out of interest-based advertising from many providers via the <a href="https://optout.networkadvertising.org/" target="_blank" rel="noopener noreferrer">NAI consumer opt-out</a> page.<br><span lang="zh"><strong>广告个性化：</strong>前往 <a href="https://adssettings.google.com/" target="_blank" rel="noopener noreferrer">Google Ads 设置</a> 管理个性化广告，或访问 <a href="https://optout.networkadvertising.org/" target="_blank" rel="noopener noreferrer">NAI 退出页面</a>关闭多个广告供应商的兴趣广告。</span></li>
+                <li><strong>Google Analytics:</strong> Install the official <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">Google Analytics Opt-out Browser Add-on</a> to stop analytics tracking across all sites that use GA.<br><span lang="zh"><strong>Google Analytics：</strong>安装官方 <a href="https://tools.google.com/dlpage/gaoptout" target="_blank" rel="noopener noreferrer">Google Analytics 退出浏览器插件</a>，即可在所有使用 GA 的网站上停用跟踪。</span></li>
+                <li><strong>Cookie control:</strong> Adjust browser settings to delete cookies or block third-party cookies. Note that disabling cookies may limit language memory and bookmark functions.<br><span lang="zh"><strong>Cookie 管理：</strong>通过浏览器设置删除或阻止第三方 Cookie。请注意，禁用 Cookie 可能影响语言记忆及收藏等功能。</span></li>
+            </ul>
+        </section>
+
+        <section class="policy-section">
+            <h2>6. Data Security & Retention 数据安全与保留</h2>
+            <p>We use trusted hosting providers and industry-standard safeguards to protect stored data. We retain usage logs only as long as necessary to analyze trends and ensure service integrity.<br><span lang="zh">我们使用可信的托管服务和行业标准安全措施保护存储数据。使用日志仅在分析趋势和保障服务稳定所需的期间内保留。</span></p>
+        </section>
+
+        <section class="policy-section">
+            <h2>7. Disclaimers 免责声明</h2>
+            <div class="policy-highlight">
+                <p>The nutrition information and recommendations on this site are for general educational purposes only and do not constitute medical advice. Always consult qualified health professionals for personal dietary decisions.<br><span lang="zh">本站提供的营养信息和推荐仅供一般教育参考，不构成医疗建议。个人饮食决策请咨询专业的医疗或营养人士。</span></p>
+                <p>Advertisements and external links are provided by third parties. We do not endorse individual products and are not responsible for the accuracy of third-party content.<br><span lang="zh">广告与外部链接由第三方提供，我们不对任何商品作出担保，也不对第三方内容的准确性承担责任。</span></p>
+            </div>
+        </section>
+
+        <section class="policy-section">
+            <h2>8. Changes to This Policy 政策变更</h2>
+            <p>We may update this policy to reflect new features or regulatory requirements. Major changes will be highlighted on this page with a revised effective date.<br><span lang="zh">我们可能会根据新功能或法规要求更新本政策。重大调整将会在本页明确提示，并更新生效日期。</span></p>
+        </section>
+
+        <section class="policy-section">
+            <h2>9. Contact Us 联系我们</h2>
+            <p>If you have privacy questions, please reach us via the contact details listed in the site footer or through WeChat: zhangyouxun2013.<br><span lang="zh">如有隐私相关问题，请通过网站页脚列出的联系方式或微信：zhangyouxun2013 与我们联系。</span></p>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-bottom">
+                <p data-i18n="footer.copyright">&copy; 2024 营养早餐. 保留所有权利.</p>
+                <div class="footer-legal-links">
+                    <a href="privacy-policy.html" data-i18n="footer.privacyPolicy">Privacy Policy</a>
+                    <a href="terms-of-service.html" data-i18n="footer.termsOfService">Terms of Service</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="i18n.js"></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1475,6 +1475,99 @@ body {
     color: #bdc3c7;
 }
 
+.footer-legal-links {
+    margin-top: 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1.5rem;
+}
+
+.footer-legal-links a {
+    color: #bdc3c7;
+    text-decoration: none;
+    font-size: 0.95rem;
+    transition: color 0.3s ease;
+}
+
+.footer-legal-links a:hover {
+    color: #ff6b6b;
+}
+
+.policy-page {
+    background: linear-gradient(135deg, #f5f7fa 0%, #e4ecf7 100%);
+}
+
+.policy-container {
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 4rem 1.5rem 5rem;
+}
+
+.policy-section {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 18px;
+    padding: 2.5rem 2rem;
+    box-shadow: 0 12px 30px rgba(44, 62, 80, 0.08);
+    margin-bottom: 2.5rem;
+}
+
+.policy-section h1,
+.policy-section h2,
+.policy-section h3 {
+    color: #2c3e50;
+    margin-bottom: 1rem;
+}
+
+.policy-section p,
+.policy-section li {
+    color: #34495e;
+    line-height: 1.8;
+    font-size: 1rem;
+}
+
+.policy-meta {
+    color: #7f8c8d;
+    font-size: 0.95rem;
+    margin-bottom: 1.5rem;
+}
+
+.policy-list {
+    margin: 1rem 0 0 1.5rem;
+    padding: 0;
+}
+
+.policy-list li {
+    margin-bottom: 0.75rem;
+}
+
+.policy-highlight {
+    background: linear-gradient(135deg, rgba(255, 107, 107, 0.12), rgba(255, 159, 67, 0.12));
+    border-left: 4px solid #ff6b6b;
+    padding: 1rem 1.25rem;
+    border-radius: 12px;
+    margin: 1.5rem 0;
+}
+
+.policy-section a {
+    color: #ff6b6b;
+    text-decoration: underline;
+}
+
+.policy-section a:hover {
+    color: #ff3b3b;
+}
+
+@media (max-width: 768px) {
+    .policy-container {
+        padding: 3rem 1.25rem 4rem;
+    }
+
+    .policy-section {
+        padding: 2rem 1.5rem;
+    }
+}
+
 /* 响应式设计 */
 @media (max-width: 768px) {
     

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -1,0 +1,109 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service | Nutrition Breakfast</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body class="policy-page">
+    <nav class="navbar">
+        <div class="nav-container">
+            <div class="nav-logo">
+                <h2>🍳 <span data-i18n="nav.title">营养早餐</span></h2>
+            </div>
+            <ul class="nav-menu">
+                <li class="nav-item"><a href="index.html" class="nav-link" data-i18n="nav.home">Home</a></li>
+                <li class="nav-item"><a href="foods.html" class="nav-link" data-i18n="nav.foods">Food Database</a></li>
+                <li class="nav-item"><a href="chinese-foods.html" class="nav-link" data-i18n="nav.chinese">Chinese Cuisine</a></li>
+                <li class="nav-item"><a href="city-foods.html" class="nav-link" data-i18n="nav.cityFoods">City Specialties</a></li>
+                <li class="nav-item"><a href="food-roulette.html" class="nav-link" data-i18n="nav.foodRoulette">Food Roulette</a></li>
+                <li class="nav-item"><a href="lunch-roulette.html" class="nav-link" data-i18n="nav.lunchRoulette">Lunch Roulette</a></li>
+                <li class="nav-item"><a href="game.html" class="nav-link" data-i18n="nav.game">Nutrition Game</a></li>
+            </ul>
+            <div class="language-switcher">
+                <button class="lang-btn" data-lang="zh" onclick="switchLanguage('zh')">中文</button>
+                <button class="lang-btn active" data-lang="en" onclick="switchLanguage('en')">English</button>
+            </div>
+        </div>
+    </nav>
+
+    <main class="policy-container">
+        <section class="policy-section">
+            <h1>Terms of Service 服务条款</h1>
+            <p class="policy-meta">Effective Date: 15 April 2024<br><span lang="zh">生效日期：2024 年 4 月 15 日</span></p>
+            <p>These Terms govern your use of Nutrition Breakfast (foodpairing.online) and all related tools. By accessing the site, you agree to these Terms and our Privacy Policy.<br><span lang="zh">本条款适用于您对 Nutrition Breakfast（foodpairing.online）及相关工具的使用。访问本网站即表示您同意本条款及隐私政策。</span></p>
+        </section>
+
+        <section class="policy-section">
+            <h2>1. Acceptance and Updates 接受与更新</h2>
+            <p>We may update these Terms to reflect new features or legal requirements. Continued use after changes constitutes acceptance of the updated Terms.<br><span lang="zh">我们可能因新增功能或法律要求更新本条款。更新后继续使用网站即表示您接受修改后的条款。</span></p>
+        </section>
+
+        <section class="policy-section">
+            <h2>2. Use of the Site 网站使用</h2>
+            <ul class="policy-list">
+                <li>Use the content for personal, non-commercial purposes only.<br><span lang="zh">网站内容仅限个人非商业用途。</span></li>
+                <li>Do not attempt to disrupt the site, reverse engineer code, or misuse data.<br><span lang="zh">禁止破坏网站、逆向工程或滥用数据。</span></li>
+                <li>Respect intellectual property. All text, images, and data belong to Nutrition Breakfast or content partners.<br><span lang="zh">请尊重知识产权。所有文字、图片和数据均归 Nutrition Breakfast 或内容合作方所有。</span></li>
+            </ul>
+        </section>
+
+        <section class="policy-section">
+            <h2>3. User Responsibilities 用户责任</h2>
+            <ul class="policy-list">
+                <li>Ensure the accuracy of any information you submit via feedback forms or comments.<br><span lang="zh">通过反馈或评论提交信息时，请确保内容准确。</span></li>
+                <li>Use the site in compliance with applicable laws and regulations in your jurisdiction.<br><span lang="zh">请在所属司法辖区的法律法规允许范围内使用本网站。</span></li>
+            </ul>
+        </section>
+
+        <section class="policy-section">
+            <h2>4. Advertising, Cookies, and Analytics 广告、Cookie 与分析</h2>
+            <p>We display third-party advertisements through Google AdSense and use Google Analytics (gtag.js) to understand site usage. By using the site, you consent to the placement of cookies and data collection described in the <a href="privacy-policy.html">Privacy Policy</a>.<br><span lang="zh">本网站通过 Google AdSense 展示第三方广告，并使用 Google Analytics（gtag.js）了解访问情况。使用本网站即表示您同意按照<a href="privacy-policy.html">隐私政策</a>中所述放置 Cookie 和收集数据。</span></p>
+            <p>You may opt out of personalized advertising or analytics tracking using the tools described in the Privacy Policy.<br><span lang="zh">您可按照隐私政策中的说明，选择退出个性化广告或 Analytics 跟踪。</span></p>
+        </section>
+
+        <section class="policy-section">
+            <h2>5. Health & Nutrition Disclaimer 健康与营养免责声明</h2>
+            <div class="policy-highlight">
+                <p>The nutrition database, roulette recommendations, and articles are for educational purposes only. They do not replace advice from doctors, dietitians, or other licensed professionals.<br><span lang="zh">本站的营养数据库、转盘推荐及文章仅供教育用途，不可替代医生、营养师或其他专业人士的建议。</span></p>
+                <p>You are responsible for evaluating the accuracy and applicability of the information before acting on it.<br><span lang="zh">在采取行动之前，请自行评估信息的准确性和适用性。</span></p>
+            </div>
+        </section>
+
+        <section class="policy-section">
+            <h2>6. Limitation of Liability 责任限制</h2>
+            <p>Nutrition Breakfast is provided “as is.” We are not liable for any direct or indirect damages arising from the use of this site, including decisions based on nutrition data, third-party advertisements, or technical errors.<br><span lang="zh">Nutrition Breakfast 按“现状”提供。因使用本站（包括依据营养数据作出的决定、第三方广告或技术错误）造成的任何直接或间接损失，我们概不负责。</span></p>
+        </section>
+
+        <section class="policy-section">
+            <h2>7. Third-Party Links 第三方链接</h2>
+            <p>Our site may contain links to external websites and services. We are not responsible for the content, policies, or security practices of those third parties.<br><span lang="zh">本网站可能包含指向外部网站和服务的链接，我们不对第三方网站的内容、政策或安全措施负责。</span></p>
+        </section>
+
+        <section class="policy-section">
+            <h2>8. Termination 终止</h2>
+            <p>We reserve the right to suspend or terminate access to the site for any user who violates these Terms or misuses our services.<br><span lang="zh">若用户违反本条款或滥用我们的服务，我们保留暂停或终止其访问权限的权利。</span></p>
+        </section>
+
+        <section class="policy-section">
+            <h2>9. Contact 联系我们</h2>
+            <p>For questions about these Terms, please reach out using the contact details listed in the footer or via WeChat: zhangyouxun2013.<br><span lang="zh">如对本条款有疑问，请通过页脚提供的联系方式或微信：zhangyouxun2013 与我们联系。</span></p>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <div class="container">
+            <div class="footer-bottom">
+                <p data-i18n="footer.copyright">&copy; 2024 营养早餐. 保留所有权利.</p>
+                <div class="footer-legal-links">
+                    <a href="privacy-policy.html" data-i18n="footer.privacyPolicy">Privacy Policy</a>
+                    <a href="terms-of-service.html" data-i18n="footer.termsOfService">Terms of Service</a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="i18n.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add bilingual privacy policy explaining cookie usage, Google AdSense/Analytics data practices, opt-out methods, and legal disclaimers
- create bilingual terms of service covering acceptable use, advertising disclosures, and nutrition liability statements
- link the new legal pages across global footers, extend translations, and style shared legal sections for clarity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc71c6fcc88321991364d253cb2d41