### PR TITLE
Add hotspot game link to homepage navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
                 <a href="/lunch-roulette/">Lunch</a>
                 <a href="/dinner-roulette/">Dinner</a>
                 <a href="/pairing/">Pairings</a>
+                <a href="https://hotspotgame.online/" target="_blank" rel="noopener">热点游戏</a>
                 <a href="/faq/">FAQ</a>
                 <a href="/about/">About</a>
                 <a href="/contact/">Contact</a>


### PR DESCRIPTION
## Summary
- add a Hotspot Game menu item to the homepage navigation bar that links to hotspotgame.online

## Testing
- no tests were run (not required for this change)

------
https://chatgpt.com/codex/tasks/task_e_68e0c1effcfc832194c94e44f2b2c702